### PR TITLE
List all instead of only the first one found

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -9,4 +9,4 @@ list_packages() {
 		grep -Eio "shellcheck-v[0-9]\.[0-9]\.[0-9]\.$os\.x86_64.tar.xz"
 }
 
-list_packages | grep -oE "[0-9]\.[0-9]\.[0-9]" | uniq
+list_packages | grep -oE "[0-9]\.[0-9]\.[0-9]" | uniq | tr "\n" " "


### PR DESCRIPTION
Currently the plugin lists only the first one found.

```
$ asdf list-all shellcheck                                                 
0.4.6
```

Modified it so that it prints all the versions in a single line like asdf expects. 
```
./asdf-shellcheck/bin/list-all                                                                                                                        
0.4.6 0.4.7 0.5.0 0.6.0 0.7.0 
```
This makes it so asdf list-all shellcheck outputs the correct information. 

```$ asdf list-all shellcheck
0.4.6
0.4.7
0.5.0
0.6.0
0.7.0
```