### PR TITLE
fix installation url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,7 +21,7 @@ _get_download_url() {
 	local -r version="$1"
 	local -r platform="$2"
 
-	echo "https://shellcheck.storage.googleapis.com/shellcheck-v$version.$platform.x86_64.tar.xz"
+	echo "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${platform}.x86_64.tar.xz"
 }
 
 install() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 
-GH_REPO="https://github.com/koalaman/shellcheck"
+releases_url="https://api.github.com/repos/koalaman/shellcheck/releases"
+
+if [ -n "$OAUTH_TOKEN" ]; then
+	cmd="curl -s -H 'Authorization: token $OAUTH_TOKEN' $releases_url"
+else
+	cmd="curl -s $releases_url"
+fi
 
 sort_versions() {
 	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
 		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-list_github_tags() {
-	git ls-remote --tags --refs "$GH_REPO" |
-		grep -o 'refs/tags/.*' | cut -d/ -f3- |
-		sed 's/^v//'
-}
-
-list_all_versions() {
-	list_github_tags
-}
-
-list_all_versions | sort_versions | xargs echo
+eval "$cmd" |
+	grep -oE "tag_name\": *\".{1,15}\"," |
+	sed 's/tag_name\": *\"v//;s/\",//' |
+	sort_versions | grep -Ev "latest|stable" | tr "\n" " "

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 
-os="$(uname -s)"
-releases_url="https://shellcheck.storage.googleapis.com"
+GH_REPO="https://github.com/koalaman/shellcheck"
 
-list_packages() {
-	curl -s "$releases_url" |
-		sed "s/<Key>\|<\/Key/ /g" |
-		grep -Eio "shellcheck-v[0-9]\.[0-9]\.[0-9]\.$os\.x86_64.tar.xz"
+sort_versions() {
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-list_packages | grep -oE "[0-9]\.[0-9]\.[0-9]" | uniq | tr "\n" " "
+list_github_tags() {
+	git ls-remote --tags --refs "$GH_REPO" |
+		grep -o 'refs/tags/.*' | cut -d/ -f3- |
+		sed 's/^v//'
+}
+
+list_all_versions() {
+	list_github_tags
+}
+
+list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
Binaries are now hosted via github releases

see https://github.com/koalaman/shellcheck/issues/1871