### PR TITLE
Add multi-arch support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,6 +14,16 @@ test -n "$ASDF_INSTALL_PATH" || {
 }
 
 _get_arch() {
+  local arch; arch=$(uname -m)
+  case $arch in
+    armv*) arch="armv6hf";;
+    aarch64) arch="aarch64";;
+    x86_64) arch="x86_64";;
+  esac
+  echo "$arch"
+}
+
+_get_platform() {
 	uname | tr '[:upper:]' '[:lower:]'
 }
 
@@ -21,17 +31,20 @@ _get_download_url() {
 	local -r version="$1"
 	local -r platform="$2"
 
-	echo "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${platform}.x86_64.tar.xz"
+	echo "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${platform}.${arch}.tar.xz"
 }
 
 install() {
-	local -r install_type=$1
 	local -r version=$2
 	local -r install_path=$3
 	local -r tar_install_path="$install_path/shellcheck-v$version.tgz"
 	local -r bin_install_path="$install_path/bin"
-	local -r platform="$(_get_arch)"
-	local -r download_url="$(_get_download_url "$version" "$platform")"
+	local -r platform="$(_get_platform)"
+	local -r arch="$(_get_arch)"
+	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
+	# If/when it is added, remove the folling line
+	if [[ "$platform" == "darwin" ]]; then arch="x86_64"; fi
+	local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
 	local -r bin_path="$bin_install_path/shellcheck"
 
 	mkdir -p "$bin_install_path"
@@ -43,4 +56,4 @@ install() {
 	chmod +x "$bin_path"
 }
 
-install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -41,9 +41,9 @@ install() {
 	local -r tar_install_path="$install_path/shellcheck-v$version.tgz"
 	local -r bin_install_path="$install_path/bin"
 	local -r platform="$(_get_platform)"
-	local arch="$(_get_arch)"
+	local arch; arch="$(_get_arch)"
 	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
-	# If/when it is added, remove the folling line
+	# If/when it is added, remove the folling line and make arch a read-only variable.
 	if [[ "$platform" == "darwin" ]]; then arch="x86_64"; fi
 	local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
 	local -r bin_path="$bin_install_path/shellcheck"

--- a/bin/install
+++ b/bin/install
@@ -36,8 +36,8 @@ _get_download_url() {
 }
 
 install() {
-	local -r version=$2
-	local -r install_path=$3
+	local -r version=$1
+	local -r install_path=$2
 	local -r tar_install_path="$install_path/shellcheck-v$version.tgz"
 	local -r bin_install_path="$install_path/bin"
 	local -r platform="$(_get_platform)"

--- a/bin/install
+++ b/bin/install
@@ -44,7 +44,7 @@ install() {
 	local arch; arch="$(_get_arch)"
 	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
 	# If/when it is added, remove the folling line and make arch a read-only variable.
-	if [[ "$platform" == "darwin" ]]; then arch="x86_64"; fi
+	test "$platform" == "darwin" && arch="x86_64"
 	local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
 	local -r bin_path="$bin_install_path/shellcheck"
 

--- a/bin/install
+++ b/bin/install
@@ -30,6 +30,7 @@ _get_platform() {
 _get_download_url() {
 	local -r version="$1"
 	local -r platform="$2"
+	local -r arch="$3"
 
 	echo "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${platform}.${arch}.tar.xz"
 }

--- a/bin/install
+++ b/bin/install
@@ -41,7 +41,7 @@ install() {
 	local -r tar_install_path="$install_path/shellcheck-v$version.tgz"
 	local -r bin_install_path="$install_path/bin"
 	local -r platform="$(_get_platform)"
-	local -r arch="$(_get_arch)"
+	local arch="$(_get_arch)"
 	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
 	# If/when it is added, remove the folling line
 	if [[ "$platform" == "darwin" ]]; then arch="x86_64"; fi


### PR DESCRIPTION
👋  @luizm I have another multi-arch change (this time for a different linter 🤔  I wonder what i'm building). I followed the same pattered I did with shfmt (https://github.com/luizm/asdf-shfmt/pull/4). However, there was a slight workaround I had to implement because there is no darwin/aarch64 support. I don't have an arm mac to test this on to see if the x86 binary would work, but I have tested it with the other types and they all load as expected. Please let me know if there's anything else I can do for this one. 