### PR TITLE
Fixing the installer to avoid permission issues

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,11 +49,11 @@ install() {
 
 	local -r download_url="$(_get_download_url "${version}" "${platform}" "${arch}")"
 
-	mkdir -pv "${bin_install_path}"
+	mkdir -p "${bin_install_path}"
 
 	echo "Downloading shellcheck from ${download_url} to ${bin_install_path}"
 	# curl to tar, without files on disk
-	( curl -Ls "${download_url}" | tar -xJv --strip-components=1 -C "${bin_install_path}" "shellcheck-v${version}/shellcheck" )
+	curl -Ls "${download_url}" | tar -xJv --strip-components=1 -C "${bin_install_path}" "shellcheck-v${version}/shellcheck"
 	chmod +x "${bin_path}"
 }
 

--- a/bin/install
+++ b/bin/install
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-set -eo pipefail
 
-ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
+set -eo pipefail
 
 test -n "$ASDF_INSTALL_VERSION" || {
 	echo 'Missing ASDF_INSTALL_VERSION'
@@ -38,23 +37,24 @@ _get_download_url() {
 install() {
 	local -r version=$1
 	local -r install_path=$2
-	local -r tar_install_path="$install_path/shellcheck-v$version.tgz"
-	local -r bin_install_path="$install_path/bin"
+
+	local -r bin_install_path="${install_path}/bin"
+	local -r bin_path="${bin_install_path}/shellcheck"
+
 	local -r platform="$(_get_platform)"
 	local arch; arch="$(_get_arch)"
 	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
 	# If/when it is added, remove the folling line and make arch a read-only variable.
 	test "$platform" == "darwin" && arch="x86_64"
-	local -r download_url="$(_get_download_url "$version" "$platform" "$arch")"
-	local -r bin_path="$bin_install_path/shellcheck"
 
-	mkdir -p "$bin_install_path"
-	echo "Downloading shellcheck from $download_url"
-	curl -Ls "$download_url" -o "$tar_install_path"
-	tar -xf "$tar_install_path"
-	cp "shellcheck-v$version/shellcheck" "$bin_path"
-	rm -rf "shellcheck-v$version"
-	chmod +x "$bin_path"
+	local -r download_url="$(_get_download_url "${version}" "${platform}" "${arch}")"
+
+	mkdir -pv "${bin_install_path}"
+
+	echo "Downloading shellcheck from ${download_url} to ${bin_install_path}"
+	# curl to tar, without files on disk
+	( curl -Ls "${download_url}" | tar -xJv --strip-components=1 -C "${bin_install_path}" "shellcheck-v${version}/shellcheck" )
+	chmod +x "${bin_path}"
 }
 
 install "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
This fixes the installation issue here: https://github.com/luizm/asdf-shellcheck/issues/5

I also did some housekeeping to cleanup unused variables, and no longer write any files to disk during the installation process.

```
$ asdf plugin test shellcheck https://github.com/lhriley/asdf-shellcheck.git --asdf-plugin-gitref fix-installer shellcheck
Updating shellcheck to fix-installer
From https://github.com/lhriley/asdf-shellcheck
 * [new branch]      fix-installer -> fix-installer
Switched to branch 'fix-installer'
mkdir: created directory '/tmp/asdf.vVR2/installs/shellcheck/0.8.0/bin'
Downloading shellcheck from https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz to /tmp/asdf.vVR2/installs/shellcheck/0.8.0/bin
shellcheck-v0.8.0/shellcheck
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
```