### PR TITLE
Replace ceased travis-ci.org with GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  plugin_test:
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: asdf-vm/actions/plugin-test@v1
+        with:
+          command: 'shellcheck --version'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: c
-script: asdf plugin-test shellcheck https://github.com/luizm/asdf-shellcheck.git
-before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
-  - source asdf/asdf.sh
-os:
-  - linux

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-shellcheck
 
-[![Build Status](https://travis-ci.org/Luizm/asdf-shellcheck.svg?branch=master)](https://travis-ci.org/luizm/asdf-shellcheck)
+[![Build Status](https://github.com/luizm/asdf-shellcheck/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/luizm/asdf-shellcheck/actions/workflows/build.yml?query=branch%3Amaster)
 
 [shellcheck](https://github.com/koalaman/shellcheck) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 


### PR DESCRIPTION
I have noticed current green badge shows old state. Targeted ref is committed in 3 years ago.

https://blog.travis-ci.com/2021-05-07-orgshutdown