### PR TITLE
Add support for Darwin/ARM version of shellcheck

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,9 +43,14 @@ install() {
 
 	local -r platform="$(_get_platform)"
 	local arch; arch="$(_get_arch)"
-	# Currently there is no darwin/arm support: https://github.com/koalaman/shellcheck/releases
-	# If/when it is added, remove the folling line and make arch a read-only variable.
-	test "$platform" == "darwin" && arch="x86_64"
+	# Shellcheck supports Darwin/ARM only starting from v0.10.0.
+	# If the requested version is lower than v0.10.0, then fall back to the x86_64 version.
+	local -r version_parts=(${version//./ })
+	if [ "${version_parts[0]}" -eq 0 ] && [ "${version_parts[1]}" -lt 10 ]; then
+		test "$platform" == "darwin" && arch="x86_64"
+	else
+		test "$platform" == "darwin" && arch="aarch64"
+	fi
 
 	local -r download_url="$(_get_download_url "${version}" "${platform}" "${arch}")"
 


### PR DESCRIPTION
Hi, this pull requests adds support for Darwin/ARM version of `shellcheck`.
Shellcheck started providing binaries for Darwin/ARM [from v0.10.0 only](https://github.com/koalaman/shellcheck/releases/tag/v0.10.0). I optionally decided to keep compatibility with older versions: If the requested version is lower than 0.10 then fallback to `x86_64` arch.

Here some tests of introduced changes. I use `mise` but I think `asdf` should also work fine since `mise` is fully compatible with `asdf`. Starting with the clean state:

```
❯ mise ls shellcheck
Plugin  Version  Config Source Requested
```

Asking to install `0.9.0` version with `mise install --verbose shellcheck@0.9.0`:

```plaintext
❯ mise install --verbose shellcheck@0.9.0
[DEBUG] ARGS: /Users/vslobodin/.local/bin/mise install --verbose shellcheck@0.9.0
[DEBUG] Config {
    Config Files: [
        "~/.config/mise/config.toml",
    ],
}
[DEBUG] install_versions: shellcheck@0.9.0
installing
~/.local/share/mise/plugins/shellcheck/bin/install
[DEBUG] $ ~/.local/share/mise/plugins/shellcheck/bin/install
Downloading shellcheck from https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.darwin.x86_64.tar.xz to /Users/vslobodin/.local/share/mise/installs/shellcheck/0.9.0/bin
x shellcheck
mise shellcheck@0.9.0         ✓ installed
```

And the same test but without specifying the patch version: `mise install --verbose shellcheck@0.9`:

```plaintext
❯ mise install --verbose shellcheck@0.9
[DEBUG] ARGS: /Users/vslobodin/.local/bin/mise install --verbose shellcheck@0.9
[DEBUG] Config {
    Config Files: [
        "~/Development/asdf-shellcheck/.mise.toml",
        "~/.config/mise/config.toml",
    ],
}

[DEBUG] install_versions: shellcheck@0.9
installing
~/.local/share/mise/plugins/shellcheck/bin/install
[DEBUG] $ ~/.local/share/mise/plugins/shellcheck/bin/install
Downloading shellcheck from https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.darwin.x86_64.tar.xz to /Users/vslobodin/.local/share/mise/installs/shellcheck/0.9.0/bin
x shellcheck
mise shellcheck@0.9.0         ✓ installed
```

I am on Darwin/ARM system, so this version should fail to run:

```plaintext
❯ shellcheck --version
exec: Failed to execute process '/Users/vslobodin/.local/share/mise/installs/shellcheck/0.9.0/bin/shellcheck': Bad CPU type in executable.
```

Now, the same tests but against v0.10.0:

Installing with specifying the patch version `mise install --verbose shellcheck@0.10.0`:

```plaintext
❯ mise install --verbose shellcheck@0.10.0
[DEBUG] ARGS: /Users/vslobodin/.local/bin/mise install --verbose shellcheck@0.10.0
[DEBUG] Config {
    Config Files: [
        "~/Development/asdf-shellcheck/.mise.toml",
        "~/.config/mise/config.toml",
    ],
}

[DEBUG] install_versions: shellcheck@0.10.0
installing
~/.local/share/mise/plugins/shellcheck/bin/install
[DEBUG] $ ~/.local/share/mise/plugins/shellcheck/bin/install
Downloading shellcheck from https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.aarch64.tar.xz to /Users/vslobodin/.local/share/mise/installs/shellcheck/0.10.0/bin
x shellcheck
mise shellcheck@0.10.0        ✓ installed
```

This version should run on a Darwin/ARM system just fine:

```plaintext
❯ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.10.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
```

It works! And the last test with installing v0.10.0 but without specifying the patch version `mise install --verbose shellcheck@0.10`:

```plaintext
❯ mise install --verbose shellcheck@0.10
[DEBUG] ARGS: /Users/vslobodin/.local/bin/mise install --verbose shellcheck@0.10
[DEBUG] Config {
    Config Files: [
        "~/Development/asdf-shellcheck/.mise.toml",
        "~/.config/mise/config.toml",
    ],
}

[DEBUG] install_versions: shellcheck@0.10
installing
~/.local/share/mise/plugins/shellcheck/bin/install
[DEBUG] $ ~/.local/share/mise/plugins/shellcheck/bin/install
Downloading shellcheck from https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.darwin.aarch64.tar.xz to /Users/vslobodin/.local/share/mise/installs/shellcheck/0.10.0/bin
x shellcheck
mise shellcheck@0.10.0        ✓ installed
```

It installs the correct version. All tests passed!

Let me know please if the compatibility for previous versions is not required, I am fine with removing it. Thanks!