### PR TITLE
Pin asdf-vm/actions and the asdf-vm version for pre-0.16.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: 'asdf-vm/actions' # v4 treats asdf-vm v0.16.0+ as the primary version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,4 @@ jobs:
       - uses: asdf-vm/actions/plugin-test@v3
         with:
           command: 'shellcheck --version'
+          asdf_branch: 'v0.15.0' # v0.16.0 introduced breaking changes


### PR DESCRIPTION
Closes #14 and closes #15 for now

---

asdf-vm introduced breaking changes in 0.16.0. It seems this plugin currently only supports versions prior to 0.16.0.
Therefore, I'm suppressing the noisy Dependabot PRs for now. This guard can be removed once we support the new asdf-vm version.
