### PR TITLE
Update GitHub hosted macOS runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14 # aarch64
-          - macos-13 # x86_64
+          - macos-15 # aarch64
+          - macos-15-intel # x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: asdf-vm/actions/plugin-test@v3


### PR DESCRIPTION
If runner speed is not a concern, there is some merit to remaining on the older runner to ensure environment support.
However, since macos-13 runner will be deprecated in a few months, now seems like the right time to update to macOS 15.

`https://github.com/actions/runner-images/issues/13045`